### PR TITLE
Feat: 숙소 전체 조회 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
-*.yml
+src/main/resources/*.yml
 
 ### IntelliJ IDEA ###
 .idea

--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,19 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	runtimeOnly 'com.h2database:h2'
+	testRuntimeOnly 'com.h2database:h2'
+
+	//myBatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.1'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/controller/AccommodationController.java
@@ -1,19 +1,45 @@
 package com.ybe.tr1ll1on.domain.accommodation.controller;
 
+import com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationRequestDTO;
 import com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationResponseDTO;
+import com.ybe.tr1ll1on.domain.accommodation.error.InvalidDateException;
 import com.ybe.tr1ll1on.domain.accommodation.service.AccommodationService;
-import java.util.List;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.ybe.tr1ll1on.domain.accommodation.error.InvalidDateExceptionCode.CHECKIN_IS_AFTER_CHECKOUT;
+
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/products")
 public class AccommodationController {
     private final AccommodationService accommodationService;
 
     @GetMapping("/test")
     public List<AccommodationResponseDTO> getTest() {
         return accommodationService.getAll();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AccommodationResponseDTO>> getAll(
+            @RequestBody @Valid AccommodationRequestDTO accommodationRequestDTO,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String region
+    ) {
+        if (!accommodationRequestDTO.getCheckOut().isBefore(accommodationRequestDTO.getCheckIn())) {
+            throw new InvalidDateException(CHECKIN_IS_AFTER_CHECKOUT);
+        }
+        if (category != null) {
+            accommodationRequestDTO.setCategory(category);
+        }
+        if (region != null) {
+            accommodationRequestDTO.setAreaCode(region);
+        }
+        return ResponseEntity.ok(accommodationService.findAccommodation(accommodationRequestDTO));
     }
 }

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/controller/AccommodationController.java
@@ -31,7 +31,7 @@ public class AccommodationController {
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String region
     ) {
-        if (!accommodationRequestDTO.getCheckOut().isBefore(accommodationRequestDTO.getCheckIn())) {
+        if (!accommodationRequestDTO.getCheckOut().isAfter(accommodationRequestDTO.getCheckIn())) {
             throw new InvalidDateException(CHECKIN_IS_AFTER_CHECKOUT);
         }
         if (category != null) {

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/dto/AccommodationRequestDTO.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/dto/AccommodationRequestDTO.java
@@ -1,0 +1,24 @@
+package com.ybe.tr1ll1on.domain.accommodation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccommodationRequestDTO {
+    @NotNull
+    LocalDate checkIn;
+    @NotNull
+    LocalDate checkOut;
+    @NotNull
+    @Min(message = "인원 수는 1명 이상이어야 합니다", value = 1L)
+    Integer personNumber;
+    String category;
+    String areaCode;
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/dto/AccommodationResponseDTO.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/dto/AccommodationResponseDTO.java
@@ -1,13 +1,34 @@
 package com.ybe.tr1ll1on.domain.accommodation.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import com.ybe.tr1ll1on.domain.accommodation.model.AccommodationImage;
+import lombok.*;
 
-@AllArgsConstructor
+
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class AccommodationResponseDTO {
-    private Long id;
+    private Long accommodationId;
+    private String imageUrl;
     private String name;
+    private String address;
+    private String areaCode;
+    private Integer price;
+    private Double score;
+
+    public AccommodationResponseDTO(Long accommodationId, String imageUrl, String name, String address, String areaCode, Integer price) {
+        this.accommodationId = accommodationId;
+        this.imageUrl = imageUrl==null ? AccommodationImage.BASIC_ACCOMMODATION_IMG : imageUrl;
+        this.name = name;
+        this.address = address;
+        this.areaCode = areaCode;
+        this.price = price;
+    }
+
+    public AccommodationResponseDTO(Long accommodationId, String name) {
+        this.accommodationId = accommodationId;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/error/InvalidDateException.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/error/InvalidDateException.java
@@ -1,0 +1,10 @@
+package com.ybe.tr1ll1on.domain.accommodation.error;
+
+import com.ybe.tr1ll1on.global.exception.ExceptionCode;
+import com.ybe.tr1ll1on.global.exception.TrillionException;
+
+public class InvalidDateException extends TrillionException {
+    public InvalidDateException(ExceptionCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/error/InvalidDateExceptionCode.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/error/InvalidDateExceptionCode.java
@@ -1,0 +1,17 @@
+package com.ybe.tr1ll1on.domain.accommodation.error;
+
+import com.ybe.tr1ll1on.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum InvalidDateExceptionCode implements ExceptionCode {
+
+    CHECKIN_IS_AFTER_CHECKOUT(HttpStatus.BAD_REQUEST, "CHECKIN_IS_AFTER_CHECKOUT", "체크인 날짜는 체크아웃 날짜 이후일 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/error/InvalidDateExceptionCode.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/error/InvalidDateExceptionCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum InvalidDateExceptionCode implements ExceptionCode {
 
-    CHECKIN_IS_AFTER_CHECKOUT(HttpStatus.BAD_REQUEST, "CHECKIN_IS_AFTER_CHECKOUT", "체크인 날짜는 체크아웃 날짜 이후일 수 없습니다");
+    CHECKIN_IS_AFTER_CHECKOUT(HttpStatus.BAD_REQUEST, "CHECKIN_IS_AFTER_CHECKOUT", "체크아웃 날짜는 체크인 날짜 이후여야 합니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/model/AccommodationImage.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/model/AccommodationImage.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AccommodationImage {
+
+    public static final String BASIC_ACCOMMODATION_IMG ="https://file.notion.so/f/f/7832e073-41e7-42fa-bde1-be449c2ae653/d781a1ed-399a-4e7c-a685-1345854836e7/Untitled.png?id=3e1513b0-8771-4977-8f3f-312841ba94e3&table=block&spaceId=7832e073-41e7-42fa-bde1-be449c2ae653&expirationTimestamp=1701043200000&signature=G-Hl7Ke4BxCYKYmQUblHz6zObkeKuq4jDuAkTUUblyg&downloadName=Untitled.png";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "accommodation_image_id")

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/repository/AccommodationMapper.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/repository/AccommodationMapper.java
@@ -1,0 +1,13 @@
+package com.ybe.tr1ll1on.domain.accommodation.repository;
+
+import com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationRequestDTO;
+import com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface AccommodationMapper {
+
+    List<AccommodationResponseDTO> findAvailableAccommodation(AccommodationRequestDTO request);
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/accommodation/service/AccommodationService.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/accommodation/service/AccommodationService.java
@@ -1,18 +1,27 @@
 package com.ybe.tr1ll1on.domain.accommodation.service;
 
+import com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationRequestDTO;
 import com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationResponseDTO;
 import com.ybe.tr1ll1on.domain.accommodation.model.Accommodation;
+import com.ybe.tr1ll1on.domain.accommodation.repository.AccommodationMapper;
 import com.ybe.tr1ll1on.domain.accommodation.repository.AccommodationRepository;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AccommodationService {
+
     private final AccommodationRepository accommodationRepository;
+    private final AccommodationMapper mapper;
 
     @Transactional
     public List<AccommodationResponseDTO> getAll() {
@@ -25,5 +34,27 @@ public class AccommodationService {
                     new AccommodationResponseDTO(accommodation.getId(), accommodation.getName()));
         }
         return accommodationResponseDTOList;
+    }
+
+    @Transactional
+    public List<AccommodationResponseDTO> findAccommodation(AccommodationRequestDTO accommodationRequestDTO){
+        return mapper.findAvailableAccommodation(accommodationRequestDTO)
+                .stream()
+                .map(it -> AccommodationResponseDTO.builder()
+                        .accommodationId(it.getAccommodationId())
+                        .imageUrl(it.getImageUrl())
+                        .name(it.getName())
+                        .price(it.getPrice())
+                        .address(it.getAddress())
+                        .areaCode(it.getAreaCode())
+                        .score(randomScore())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private Double randomScore() {
+        double score = Math.random() * 5.0;
+        DecimalFormat decimalFormat = new DecimalFormat("#.##");
+        return Double.parseDouble(decimalFormat.format(score));
     }
 }

--- a/src/main/java/com/ybe/tr1ll1on/global/config/MybatisConfig.java
+++ b/src/main/java/com/ybe/tr1ll1on/global/config/MybatisConfig.java
@@ -1,0 +1,36 @@
+package com.ybe.tr1ll1on.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+import javax.sql.DataSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class MybatisConfig {
+
+    private final DataSource dataSource;
+    private final ApplicationContext context;
+    @Bean
+    public SqlSessionFactory sqlSessionFactory() throws Exception {
+        SqlSessionFactoryBean sqlSessionFactoryBean
+                = new SqlSessionFactoryBean();
+        sqlSessionFactoryBean.setDataSource(dataSource);
+        Resource[] resources = context.getResources("classpath:mapper/*.xml");
+        sqlSessionFactoryBean.setMapperLocations(resources);
+
+        return sqlSessionFactoryBean.getObject();
+    }
+
+    @Bean
+    public SqlSessionTemplate sqlSessionTemplate() throws Exception {
+        return new SqlSessionTemplate(sqlSessionFactory());
+    }
+
+}

--- a/src/main/resources/mapper/AccommodationMapper.xml
+++ b/src/main/resources/mapper/AccommodationMapper.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTO Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ybe.tr1ll1on.domain.accommodation.repository.AccommodationMapper">
+
+    <select id="findAvailableAccommodation"
+            parameterType="com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationRequestDTO"
+            resultType="com.ybe.tr1ll1on.domain.accommodation.dto.AccommodationResponseDTO">
+
+        select main.accommodationId as accommodationId,
+               main.imageUrl        as imageUrl,
+               main.address         as address,
+               main.areaCode        as areaCode,
+               main.name            as name,
+               min(main.total)      as price
+        from (select accommodationId, imageUrl, address, areaCode, name, sum(price) as total
+              from (select a.accommodation_id as accommodationId,
+                           image_url          as imageUrl,
+                           address            as address,
+                           area_code          as areaCode,
+                           a.name             as name,
+                           price              as price,
+                           p.product_id       as productId
+                    from accommodation a
+                             left join (select image_url, accommodation_id
+                                        from accommodation_image
+                                        where accommodation_image_id in (select min(accommodation_image_id)
+                                                                         from accommodation_image
+                                                                         group by accommodation_id)) ai
+                                       on a.accommodation_id = ai.accommodation_id
+                             left join category c on a.category_id = c.category_id
+                             left join product p on a.accommodation_id = p.accommodation_id
+                             left join product_info_per_night pipn
+                                       on pipn.product_id = p.product_id and date between #{checkIn} and #{checkOut}
+                    where p.maximum_number <![CDATA[>=]]>
+                          #{personNumber}
+                        <if test="category != null">
+                            and c.category_code = #{category}
+                        </if>
+                        <if test="areaCode != null">
+                            and a.area_code = #{areaCode}
+                        </if>
+                    ) as sub
+              group by sub.accommodationId, sub.imageUrl, sub.address, sub.areaCode, sub.name, sub.productId) as main
+        group by main.accommodationId, main.imageUrl, main.address, main.areaCode, main.name
+    </select>
+</mapper>


### PR DESCRIPTION
resolve: #6 
---
:sparkles: 해당 기능을 구현하기 위하여 mybatis를 사용하였습니다
이로 인해 라이브러리 추가와 관련 설정 파일들을 추가하였습니다 :sparkles:

## 기능 설명
숙소 조회시 보여주는 정보
- 숙소 이름
- 숙소 대표 이미지 1장
- 숙소 주소
- 지역 코드
- 숙소 가격
  - 한 숙소당 입력된 체크인, 체크아웃 기간 동안의 객실 가격 합계들 중 최소 가격
- 평점

### 1. 전체 숙소 조회- 아무 조건 x
로그인 하지 않고, 아무 카테고리 조건을 걸지 않았을 경우 디비에 저장되어 있는 모든 숙소 조회
![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/97935558/8bda905b-8034-452a-97ae-312d99473281)

### 2. 전체 숙소 조회 - 카테고리 코드 조건
파라미터로 카테고리 조건이 넘어왔을 경우 해당 카테고리에 해당하는 숙소 조회
![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/97935558/15aebd8c-598d-4eb1-9f16-dc90fe98fc5b)

### 3. 전체 숙소 조회 - 지역 조건
파라미터로 지역 조건이 넘어왔을 경우 해당 카테고리에 해당하는 숙소 조회
![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/97935558/a1f605af-772d-4388-a8f5-9a03ae3dd9c8)

### 4. 전체 숙소 조회 - 카테고리 코드+지역 조건
파라미터로 카테고리 코드, 지역 조건 둘 다 넘어왔을 경우 조건에 해당하는 숙소 조회
![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/97935558/42042179-2066-46e2-be84-ac4e08e22872)

---
### 고민했던 것
쿼리문을 작성하지 않고 쿼리 메서드를 사용하여 위 정보들을 나타내려 했으나
-> 한 숙소에 해당 하는 가격을 가져오기 위하여 숙소 갯수만큼의 쿼리문이 나가게 되어 성능 저하 문제 발생

조건의 유무에 따라 쿼리문을 어떻게 재사용할 수 있나
-> jdbcTemplate는 동적 쿼리 작성에 있어서 어려움이 있었음
-> querydsl을 사용하여 해결하려 하였으나 가격을 구하는 과정에서 from절에 서브쿼리를 넣을 수 없는 문제 발생
-> **mybatis**를 사용하여 해당 문제 해결 :thumbsup:
