### PR TITLE
Feat : 찜 추가/제거 기능 및 마이페이지 찜 조회 기능 개발 

### DIFF
--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/controller/LikeController.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/controller/LikeController.java
@@ -1,4 +1,48 @@
 package com.ybe.tr1ll1on.domain.likes.controller;
 
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeMessageResponse;
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeResponse;
+import com.ybe.tr1ll1on.domain.likes.service.LikeService;
+import com.ybe.tr1ll1on.domain.order.dto.request.OrderRequest;
+import com.ybe.tr1ll1on.domain.order.dto.response.OrderResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "좋아요(찜) API", description = "좋아요(찜) 관련 API 모음입니다.")
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/likes")
 public class LikeController {
+
+    private final LikeService likeService;
+
+    @Operation(summary = "찜 누르기 API", description = "찜 누르기 API 입니다.")
+    @ApiResponse(responseCode = "201", description = "찜 성공시",
+            content = @Content(schema = @Schema(implementation = LikeResponse.class)))
+    @SecurityRequirement(name = "jwt")
+    @PostMapping("/{accommodationId}")
+    public ResponseEntity<LikeMessageResponse> toggleLike(
+            @PathVariable Long accommodationId
+    ) {
+        return ResponseEntity.ok(likeService.toggleLike(accommodationId));
+    }
+
 }
+

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/dto/LikeDTO.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/dto/LikeDTO.java
@@ -1,4 +1,0 @@
-package com.ybe.tr1ll1on.domain.likes.dto;
-
-public class LikeDTO {
-}

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/dto/response/LikeMessageResponse.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/dto/response/LikeMessageResponse.java
@@ -1,0 +1,31 @@
+package com.ybe.tr1ll1on.domain.likes.dto.response;
+
+import com.ybe.tr1ll1on.domain.likes.model.Likes;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+public class LikeMessageResponse {
+    @Schema(example = "1")
+    private Long likeId;
+
+    @Schema(example = "좋아요 성공")
+    private String message;
+
+    @Schema(example = "18")
+    private Long accommodationId;
+
+    public static LikeMessageResponse fromEntity(Likes likes, String message) {
+        return LikeMessageResponse.builder()
+                .likeId(likes.getId())
+                .message(message)
+                .accommodationId(likes.getAccommodation().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/dto/response/LikeResponse.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/dto/response/LikeResponse.java
@@ -1,0 +1,51 @@
+package com.ybe.tr1ll1on.domain.likes.dto.response;
+
+import com.ybe.tr1ll1on.domain.likes.model.Likes;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.DateTimeFormatter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+public class LikeResponse {
+    @Schema(example = "1")
+    private Long likeId;
+
+    @Schema(example = "18")
+    private Long accommodationId;
+
+    @Schema(example = "해와달수상낚시빌리지")
+    private String accommodationName;
+
+    @Schema(example = "경기도 포천시 관인면 냉정리")
+    private String accommodationAddress;
+
+    @Schema(example = "B02010700")
+    private String accommodationCategory;
+
+    @Schema(example = "http://tong.visitkorea.or.kr/cms/resource/50/2705650_image2_1.jpg")
+    private String imageUrl;
+
+    @Schema(example = "2023년 12월 09일 01시 23분")
+    private String createdAt;
+
+    public static LikeResponse fromEntity(Likes likes) {
+        return LikeResponse.builder()
+                .likeId(likes.getId())
+                .accommodationId(likes.getAccommodation().getId())
+                .accommodationName(likes.getAccommodation().getName())
+                .accommodationAddress(likes.getAccommodation().getAddress())
+                .accommodationCategory(likes.getAccommodation().getCategory().getCategoryCode())
+                .imageUrl(likes.getAccommodation().getAccommodationImageList().get(0).getImageUrl())
+                .createdAt(likes.getCreatedAt().format(
+                        DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")
+                ))
+                .build();
+    }
+}
+

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/error/LikeError.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/error/LikeError.java
@@ -1,4 +1,0 @@
-package com.ybe.tr1ll1on.domain.likes.error;
-
-public class LikeError {
-}

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/exception/LikeException.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/exception/LikeException.java
@@ -1,0 +1,11 @@
+package com.ybe.tr1ll1on.domain.likes.exception;
+
+import com.ybe.tr1ll1on.global.exception.ExceptionCode;
+import com.ybe.tr1ll1on.global.exception.TrillionException;
+
+public class LikeException extends TrillionException {
+
+    public LikeException(ExceptionCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/exception/LikeExceptionCode.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/exception/LikeExceptionCode.java
@@ -1,0 +1,20 @@
+package com.ybe.tr1ll1on.domain.likes.exception;
+
+import com.ybe.tr1ll1on.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum LikeExceptionCode implements ExceptionCode {
+
+    FAILED_LIKE(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR", "찜을 처리하지 못 했습니다."),
+    LIKES_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT FOUND", "찜 정보를 찾지 못했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String msg;
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/model/Likes.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/model/Likes.java
@@ -3,12 +3,17 @@ package com.ybe.tr1ll1on.domain.likes.model;
 import com.ybe.tr1ll1on.domain.accommodation.model.Accommodation;
 import com.ybe.tr1ll1on.domain.user.model.User;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Likes {
 
     @Id
@@ -23,4 +28,8 @@ public class Likes {
     @ManyToOne
     @JoinColumn(name = "accommodation_id")
     private Accommodation accommodation;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 }
+

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/repository/LikeRepository.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/repository/LikeRepository.java
@@ -1,4 +1,14 @@
 package com.ybe.tr1ll1on.domain.likes.repository;
 
-public interface LikeRepository {
+import com.ybe.tr1ll1on.domain.likes.model.Likes;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Likes, Long> {
+    Optional<Likes> findByUserIdAndAccommodationId(Long userId, Long accommodationId);
+
 }
+

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/service/LikeService.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/service/LikeService.java
@@ -1,4 +1,14 @@
 package com.ybe.tr1ll1on.domain.likes.service;
 
-public class LikeService {
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeMessageResponse;
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeResponse;
+import com.ybe.tr1ll1on.domain.likes.model.Likes;
+import com.ybe.tr1ll1on.domain.user.model.User;
+import java.util.List;
+
+public interface LikeService {
+
+    LikeMessageResponse toggleLike(Long accommodationId);
+
 }
+

--- a/src/main/java/com/ybe/tr1ll1on/domain/likes/service/LikeServiceImpl.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/likes/service/LikeServiceImpl.java
@@ -1,0 +1,80 @@
+package com.ybe.tr1ll1on.domain.likes.service;
+
+import static com.ybe.tr1ll1on.domain.accommodation.exception.AccommodationExceptionCode.ACCOMMODATION_NOT_FOUND;
+import static com.ybe.tr1ll1on.domain.user.exception.InValidUserExceptionCode.USER_NOT_FOUND;
+
+import com.ybe.tr1ll1on.domain.accommodation.exception.AccommodationException;
+import com.ybe.tr1ll1on.domain.accommodation.model.Accommodation;
+import com.ybe.tr1ll1on.domain.accommodation.repository.AccommodationRepository;
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeMessageResponse;
+import com.ybe.tr1ll1on.domain.likes.exception.LikeException;
+import com.ybe.tr1ll1on.domain.likes.exception.LikeExceptionCode;
+import com.ybe.tr1ll1on.domain.likes.model.Likes;
+import com.ybe.tr1ll1on.domain.likes.repository.LikeRepository;
+import com.ybe.tr1ll1on.domain.user.exception.InValidUserException;
+import com.ybe.tr1ll1on.domain.user.model.User;
+import com.ybe.tr1ll1on.domain.user.repository.UserRepository;
+import com.ybe.tr1ll1on.security.util.SecurityUtil;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LikeServiceImpl implements LikeService {
+    private final UserRepository userRepository;
+    private final LikeRepository likeRepository;
+    private final AccommodationRepository accommodationRepository;
+
+    @Transactional
+    public LikeMessageResponse toggleLike(Long accommodationId) {
+        User user = getUser();
+
+        Optional<Likes> optionalLikes = likeRepository.findByUserIdAndAccommodationId(
+                user.getId(), accommodationId
+        );
+
+        Likes likes;
+        if (optionalLikes.isEmpty()) {  // 좋아요가 없다 => 새로운 좋아요 생성
+
+            likes = Likes.builder()
+                    .user(user)
+                    .accommodation(getAccommodation(accommodationId))
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            Likes savedLike = likeRepository.save(likes);
+            if (savedLike == null) {
+                throw new LikeException(LikeExceptionCode.FAILED_LIKE);
+            }
+
+            log.info("찜 목록 추가! 숙소 ID : {}, LikeId : {}", accommodationId, savedLike.getId());
+            return LikeMessageResponse.fromEntity(savedLike, "찜 목록에 추가하였습니다.");
+
+        } else {  // 좋아요가 있다 => 좋아요 취소
+
+            likes = optionalLikes.get();
+            likeRepository.delete(likes);
+
+            log.info("찜 목록 제거! 숙소 ID : {}, LikeId : {}", accommodationId, likes.getId());
+            return LikeMessageResponse.fromEntity(likes, "찜 목록에 제거하였습니다.");
+        }
+
+    }
+
+    private Accommodation getAccommodation(Long accommodationId) {
+        return accommodationRepository.findById(accommodationId)
+                .orElseThrow(() -> new AccommodationException(ACCOMMODATION_NOT_FOUND));
+    }
+
+
+
+    private User getUser() {
+        return userRepository.findById(SecurityUtil.getCurrentUserId())
+                .orElseThrow(() -> new InValidUserException(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ybe/tr1ll1on/domain/user/controller/UserController.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.ybe.tr1ll1on.domain.user.controller;
 
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeResponse;
 import com.ybe.tr1ll1on.domain.user.dto.response.MyPageDetailResponse;
 import com.ybe.tr1ll1on.domain.user.dto.response.MyPageResponse;
 import com.ybe.tr1ll1on.domain.user.service.UserService;
@@ -44,4 +45,15 @@ public class UserController {
         MyPageDetailResponse myPageDetailResponse = userService.getMyPageDetails(orderId);
         return ResponseEntity.ok(myPageDetailResponse);
     }
+
+    @Operation(summary = "마이페이지 - 숙소 찜 목록", description = "마이페이지에서 찜 목록 API 입니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공시",
+            content = @Content(schema = @Schema(implementation = LikeResponse.class)))
+    @SecurityRequirement(name = "jwt")
+    @GetMapping("/likes")
+    public ResponseEntity<List<LikeResponse>> getLikeList() {
+        List<LikeResponse> likeResponseList = userService.getMyLikeList();
+        return ResponseEntity.ok(likeResponseList);
+    }
+
 }

--- a/src/main/java/com/ybe/tr1ll1on/domain/user/service/UserService.java
+++ b/src/main/java/com/ybe/tr1ll1on/domain/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.ybe.tr1ll1on.domain.user.service;
 
 import static com.ybe.tr1ll1on.domain.user.exception.InValidUserExceptionCode.USER_NOT_FOUND;
 
+import com.ybe.tr1ll1on.domain.likes.dto.response.LikeResponse;
+import com.ybe.tr1ll1on.domain.likes.model.Likes;
 import com.ybe.tr1ll1on.domain.order.exception.OrderException;
 import com.ybe.tr1ll1on.domain.order.exception.OrderExceptionCode;
 import com.ybe.tr1ll1on.domain.order.model.Orders;
@@ -12,6 +14,8 @@ import com.ybe.tr1ll1on.domain.user.exception.InValidUserException;
 import com.ybe.tr1ll1on.domain.user.model.User;
 import com.ybe.tr1ll1on.domain.user.repository.UserRepository;
 import com.ybe.tr1ll1on.security.util.SecurityUtil;
+import java.util.Collections;
+import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -61,8 +65,25 @@ public class UserService {
         return myPageDetailResponse;
     }
 
+    @Transactional(readOnly = true)
+    public List<LikeResponse> getMyLikeList() {
+        User user = getUser();
+        log.info("마이페이지 찜 목록 조회!");
+
+        List<Likes> likesList = user.getLikesList();
+        // 등록한 날짜 역순으로 정렬 -> 가장 최근에 찜 누른 것부터 확인할 수 있도록 함.
+        Collections.sort(likesList, (o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt()));
+
+        return user.getLikesList()
+                .stream().map(LikeResponse::fromEntity)
+                .collect(Collectors.toList());
+
+    }
+
     private User getUser() {
         return userRepository.findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new InValidUserException(USER_NOT_FOUND));
     }
+
+
 }


### PR DESCRIPTION
# 찜 기능 

Likes 테이블에 생성 시간 (createdAt) 을 추가하였습니다. 
그러므로, 사용자는 자신이 가장 최근에 누른 찜들부터 볼 수 있습니다.

### 🌟 찜 추가 삭제는 같은 API 입니다 🌟
API : [노션 LINK](https://www.notion.so/API-556c8b2ec73a460c9132ccc9a0a2dbc1?p=9a894bc67e364a89bd07cb43983cf9e6&pm=s)

## 찜을 누르면
![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/59862752/a1723910-965a-40fc-a1c0-2fabb2f8bbb3)

## 찜을 제거하면
![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/59862752/65a75c36-b87d-4ea7-b16d-41befcb1dbf1)

# 마이페이지 찜 조회 기능 

사용자는 자신이 가장 최근에 누른 것들부터 찜 목록을 조회할 수 있습니다. 

API : [노션 LINK](https://www.notion.so/API-556c8b2ec73a460c9132ccc9a0a2dbc1?p=b3b41abdc9134d72907d0b25c4507e80&pm=s)

![image](https://github.com/TR1LL1ON/TR1LL1ON_BE/assets/59862752/38c86250-9ef8-4c1f-8195-2227ba079657)
